### PR TITLE
gopmod: lookupExternPkg error

### DIFF
--- a/gopmod/module.go
+++ b/gopmod/module.go
@@ -17,6 +17,7 @@
 package gopmod
 
 import (
+	"fmt"
 	"log"
 	"path/filepath"
 	"runtime"
@@ -130,7 +131,8 @@ func (p *Module) lookupExternPkg(pkgPath string) (pkg *Package, err error) {
 			return
 		}
 	}
-	err = syscall.ENOENT
+	err = fmt.Errorf(`no required module provides package %v; to add it:
+	go get %v`, pkgPath, pkgPath)
 	return
 }
 

--- a/gopmod/module.go
+++ b/gopmod/module.go
@@ -17,7 +17,6 @@
 package gopmod
 
 import (
-	"fmt"
 	"log"
 	"path/filepath"
 	"runtime"
@@ -131,8 +130,7 @@ func (p *Module) lookupExternPkg(pkgPath string) (pkg *Package, err error) {
 			return
 		}
 	}
-	err = fmt.Errorf(`no required module provides package %v; to add it:
-	go get %v`, pkgPath, pkgPath)
+	err = &mod.MissingPkgError{Path: pkgPath}
 	return
 }
 

--- a/gopmod/module.go
+++ b/gopmod/module.go
@@ -17,6 +17,7 @@
 package gopmod
 
 import (
+	"fmt"
 	"log"
 	"path/filepath"
 	"runtime"
@@ -130,7 +131,7 @@ func (p *Module) lookupExternPkg(pkgPath string) (pkg *Package, err error) {
 			return
 		}
 	}
-	err = &mod.MissingPkgError{Path: pkgPath}
+	err = &MissingError{Path: pkgPath}
 	return
 }
 
@@ -208,6 +209,15 @@ func loadModFrom(mod module.Version, mode mod.Mode) (p *Module, err error) {
 		return
 	}
 	return Load(dir, mode)
+}
+
+type MissingError struct {
+	Path string
+}
+
+func (e *MissingError) Error() string {
+	return fmt.Sprintf(`no required module provides package %v; to add it:
+	gop get %v`, e.Path, e.Path)
 }
 
 // -----------------------------------------------------------------------------

--- a/mod.go
+++ b/mod.go
@@ -17,7 +17,6 @@
 package mod
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,15 +66,6 @@ func GOPMOD(dir string, mode Mode) (file string, err error) {
 // GOMOD checks the modfile (go.mod) in this dir or its ancestors.
 func GOMOD(dir string) (file string, err error) {
 	return GOPMOD(dir, GoModOnly)
-}
-
-type MissingPkgError struct {
-	Path string
-}
-
-func (e *MissingPkgError) Error() string {
-	return fmt.Sprintf(`no required module provides package %v; to add it:
-	go get %v`, e.Path, e.Path)
 }
 
 // -----------------------------------------------------------------------------

--- a/mod.go
+++ b/mod.go
@@ -17,6 +17,7 @@
 package mod
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -66,6 +67,15 @@ func GOPMOD(dir string, mode Mode) (file string, err error) {
 // GOMOD checks the modfile (go.mod) in this dir or its ancestors.
 func GOMOD(dir string) (file string, err error) {
 	return GOPMOD(dir, GoModOnly)
+}
+
+type MissingPkgError struct {
+	Path string
+}
+
+func (e *MissingPkgError) Error() string {
+	return fmt.Sprintf(`no required module provides package %v; to add it:
+	go get %v`, e.Path, e.Path)
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
```
import "github.com/goplus/fmt2"
println "hello"
```
dump error
```
no required module provides package github.com/goplus/fmt2; to add it:
	go get github.com/goplus/fmt2
```