### PR TITLE
gopmod: classfile support multiple ext

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.16.x, 1.17.x]
-        os: [ubuntu-latest, windows-latest, macos-10.15, macos-11]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/gopmod/classfile.go
+++ b/gopmod/classfile.go
@@ -109,8 +109,10 @@ func (p *Module) registerClassFrom(modVer module.Version, regcls func(c *Class))
 
 func (p *Module) registerClass(c *Class, regcls func(c *Class)) {
 	p.classes[c.ProjExt] = c
-	for _, ext := range strings.Split(c.WorkExt, ";") {
-		p.classes[ext] = c
+	if c.WorkExt != "" {
+		for _, ext := range strings.Split(c.WorkExt, ";") {
+			p.classes[ext] = c
+		}
 	}
 	if regcls != nil {
 		regcls(c)

--- a/gopmod/classfile.go
+++ b/gopmod/classfile.go
@@ -18,6 +18,7 @@ package gopmod
 
 import (
 	"errors"
+	"strings"
 	"syscall"
 
 	"github.com/goplus/mod/modcache"
@@ -108,8 +109,8 @@ func (p *Module) registerClassFrom(modVer module.Version, regcls func(c *Class))
 
 func (p *Module) registerClass(c *Class, regcls func(c *Class)) {
 	p.classes[c.ProjExt] = c
-	if c.WorkExt != "" {
-		p.classes[c.WorkExt] = c
+	for _, ext := range strings.Split(c.WorkExt, ";") {
+		p.classes[ext] = c
 	}
 	if regcls != nil {
 		regcls(c)


### PR DESCRIPTION
- support  register multiple ext work files split by ; list
`classfile .gmx .spx;.spy github.com/goplus/spx`

- https://github.com/actions/runner-images remove macos-10.15
