### PR TITLE
refactor(modcache): manually resolve `GOMODCACHE` for Wasm environment

### DIFF
--- a/modcache/cache.go
+++ b/modcache/cache.go
@@ -17,10 +17,7 @@
 package modcache
 
 import (
-	"bytes"
 	"errors"
-	"log"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -32,18 +29,6 @@ import (
 var (
 	GOMODCACHE = getGOMODCACHE()
 )
-
-func getGOMODCACHE() string {
-	var buf bytes.Buffer
-	var stderr bytes.Buffer
-	cmd := exec.Command("go", "env", "GOMODCACHE")
-	cmd.Stdout = &buf
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		log.Panicln("GOMODCACHE not found:", err)
-	}
-	return strings.TrimRight(buf.String(), "\n")
-}
 
 // -----------------------------------------------------------------------------
 

--- a/modcache/cache_other.go
+++ b/modcache/cache_other.go
@@ -1,0 +1,23 @@
+//go:build !(js || wasip1)
+
+package modcache
+
+import (
+	"bytes"
+	"log"
+	"os/exec"
+	"strings"
+)
+
+// getGOMODCACHE returns the Go module cache directory.
+func getGOMODCACHE() string {
+	var buf bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := exec.Command("go", "env", "GOMODCACHE")
+	cmd.Stdout = &buf
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		log.Panicln("GOMODCACHE not found:", err)
+	}
+	return strings.TrimRight(buf.String(), "\n")
+}

--- a/modcache/cache_wasm.go
+++ b/modcache/cache_wasm.go
@@ -1,0 +1,25 @@
+//go:build js || wasip1
+
+package modcache
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// getGOMODCACHE returns the Go module cache directory. It follows the same
+// logic as the Go command:
+//  1. Use GOMODCACHE if set.
+//  2. Otherwise use $GOPATH/pkg/mod.
+//  3. If GOPATH is not set, default to "/go/pkg/mod".
+func getGOMODCACHE() string {
+	if dir := os.Getenv("GOMODCACHE"); dir != "" {
+		return dir
+	}
+
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		gopath = "/go"
+	}
+	return filepath.Join(gopath, "pkg", "mod")
+}


### PR DESCRIPTION
Since `exec.Command` is not available in Wasm environment, we resolve `GOMODCACHE` by directly checking environment variables following Go's standard behavior.